### PR TITLE
Add parameters to redirect

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umbrella"
 uuid = "fb3c7edd-4d33-4ece-bf81-49ff2d418a94"
 authors = ["Jiacheng Zhang <zhangjiacheng54@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ HTTP = "0.8, 0.9, 1.0"
 JSON3 = "1"
 StructTypes = "1.8"
 URIs = "1.3"
-julia = "1.6 - 1.8"
+julia = ">1.6 "
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ HTTP = "0.8, 0.9, 1.0"
 JSON3 = "1"
 StructTypes = "1.8"
 URIs = "1.3"
-julia = ">1.6 "
+julia = ">= 1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/mux_example.jl
+++ b/examples/mux_example.jl
@@ -44,7 +44,7 @@ end
   page("/", respond("<a href='$(oauth_path)'>Authenticate with Google</a>")),
   page(oauth_path, req -> oauth2.redirect()),
   page(oauth_callback, callback),
-  page("/protected", respond("Congrets, You signed in Successfully!")),
+  page("/protected", respond("Congrats, You signed in Successfully!")),
   Mux.notfound()
 )
 

--- a/examples/oxygen_example.jl
+++ b/examples/oxygen_example.jl
@@ -40,7 +40,7 @@ end
 end
 
 @get "/protected" function()
-  "Congrets, You signed in Successfully!"
+  "Congrats, You signed in Successfully!"
 end
 
 # start the web server

--- a/src/initiator.jl
+++ b/src/initiator.jl
@@ -59,15 +59,15 @@ function init(type::Symbol, config::Configuration.Options, redirect_hanlder::Fun
         type,
         function ()
             url = actions[:redirect](config)
-            redirect_hanlder(url)
+            redirect_hanlder(url, nothing)
         end,
         function (code::String, verify::Function)
             tokens, profile = actions[:token_exchange](code, config)
             if tokens === nothing || profile === nothing
-                return redirect_hanlder(config.failure_redirect)
+                return redirect_hanlder(config.failure_redirect, nothing)
             end
-            verify(tokens, profile)
-            redirect_hanlder(config.success_redirect)
+            params = verify(tokens, profile)
+            redirect_hanlder(config.success_redirect, params)
         end
     )
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,22 @@
 import HTTP
 
-function redirect(url::String, status::Int = 302)
-  headers = Dict{String, String}(
-    "Location" => url
-  )
+function redirect(
+        url::String, params::Dict{String, Any}=nothing,
+        status::Int = 302
+    )
 
-  HTTP.Response(status, [h for h in headers])
+    # Set redirect parameters (if they exist)
+    if ! isnothing(params)
+        uri = HTTP.URI(
+            path = url,
+            query = params
+        )
+        url = string(uri)
+    end
+
+    # Redirect to url
+    headers = Dict{String, String}(
+        "Location" => url
+    )
+    HTTP.Response(status, [h for h in headers])
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,19 +1,13 @@
 import HTTP
 
-function redirect(
-        url::String, params::Dict{String, Any}=nothing,
-        status::Int = 302
-    )
+function redirect(url::String, params::Dict{String, Any}, status::Int = 302)
+    # Set redirect parameters
+    uri = HTTP.URI(path = url, query = params)
+    redirect(string(uri), nothing, status)
+end
 
-    # Set redirect parameters (if they exist)
-    if ! isnothing(params)
-        uri = HTTP.URI(
-            path = url,
-            query = params
-        )
-        url = string(uri)
-    end
 
+function redirect(url::String, ::Nothing, status::Int = 302)
     # Redirect to url
     headers = Dict{String, String}(
         "Location" => url

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 import HTTP
 
-function redirect(url::String, params::Dict{String, Any}, status::Int = 302)
+function redirect(url::String, params::Dict{String, <:Any}, status::Int = 302)
     # Set redirect parameters
     uri = HTTP.URI(path = url, query = params)
     redirect(string(uri), nothing, status)

--- a/test/app.jl
+++ b/test/app.jl
@@ -1,7 +1,7 @@
 
 const MOCK_AUTH_URL = "https://mock.com/oauth2/"
 
-function mock_redirect(url::String) url end
+function mock_redirect(url::String, params::Nothing) url end
 
 function mock_redirect_url(config::Configuration.Options)
   "$(MOCK_AUTH_URL)?client_id=$(config.client_id)&redirect_uri=$(config.redirect_uri)&scope=$(config.scope)"
@@ -13,6 +13,7 @@ end
 
 function mock_verify(tokens, user)
   tokens, user
+  return nothing
 end
 
 register(:mock, OAuth2Actions(mock_redirect_url, mock_token_exchange))


### PR DESCRIPTION
This PR introduces the following pattern for verifying tokens and redirecting on success:
```julia
            params = verify(tokens, profile)
            redirect_hanlder(config.success_redirect, params)
```
The idea of this pattern is that the algorithm behind `verfiy` returns a `Dict` of parameters -- which can be anything. Here I am imagining that this includes a unique hash representing the result of token verification (e.g. a key to a lookup table). This can then be used by the page located at `config.success_redirect` to look up any data stored by `verify`. Note that`params` is allowed to be `nothing` (e.g. if token validation failed, or if this pattern is unused). If `params` is `nothing` then no parameters are included by `redirect_handler`.

A simple use case for this is if `verify` stores the logged in user's name using a global dict. The value in `params` can then be used to look up the user's name. Eg:
```julia
struct Users
    tokens::Dict{String, Tuple{String, String, String}}
    Users() = new(Dict{String, Tuple{String, String, String}}())
end

function add(
        users::Users, 
        email::String, access_token::String, refresh_token::String;
        length=16
    )
    while true
        new_key = randstring(['0':'9'; 'a':'f'], length)
        if ! (new_key in keys(users.tokens))
            users.tokens[new_key] = (email, access_token, refresh_token)
            return new_key
        end
    end
end

import Base.keys

keys(u::Users) = Base.keys(u.tokens)
email(u::Users, k::String) = u.tokens[k][1]
access_token(u::Users, k::String) = u.tokens[k][2]
refresh_token(u::Users, k::String) = u.tokens[k][3]

authenticated_users = Users()

@get oauth_callback function(req)
    query_params = queryparams(req)
    code = query_params["code"]

    # handle tokens and user details
    google_oauth2.token_exchange(code,
        function (tokens::Google.Tokens, user::Google.User)
            user_key = add(
                authenticated_users,
                user.email, tokens.access_token, tokens.refresh_token
            )
            return Dict("user_key" => user_key)
        end
    )
end

function is_authenticated(req)
    query_params = queryparams(req)
    if !("user_key" in keys(query_params)) return false end
    return query_params["user_key"] in keys(authenticated_users)
end

@get "/protected" function(req)
    if is_authenticated(req)
        user_key = queryparams(req)["user_key"]
        """
        <html>
            <body>
                You are successfully signed in as: $(email(authenticated_users, user_key))
                <p>
                Please go to: <a href='$(oauth_path)'>Authenticate with Google</a> to log in as a different user
            </body>
        </html>
        """
    else
        """
        <html>
            <body>
                You are not logged in, please log in by going to:
                <a href='$(oauth_path)'>Authenticate with Google</a>
            </body>
        </html>
        """
    end
end
```
In this case `params` contains only the user UUID -- but it can be whatever your application needs.

I'm thinking of how to generalize this to include a session cookie in the `redirect_handler`.